### PR TITLE
Small adjustments to recent/future changes in LinAlg.jl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
         version:
           - '1.6'
           - '1'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockBandedMatrices"
 uuid = "ffab5731-97b5-5995-9138-79e8c1846df0"
-version = "0.11.9"
+version = "0.11.10"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BandedBlockBandedMatrix.jl
+++ b/src/BandedBlockBandedMatrix.jl
@@ -613,7 +613,7 @@ end
 end
 
 
-BLAS.axpy!(a::T, A::BandedBlockBandedMatrix{T}, B::BandedBlockBandedMatrix{T}) where T =
+axpy!(a::T, A::BandedBlockBandedMatrix{T}, B::BandedBlockBandedMatrix{T}) where {T} =
     B .= a .* A .+ B
 
 

--- a/src/BlockBandedMatrices.jl
+++ b/src/BlockBandedMatrices.jl
@@ -12,7 +12,7 @@ import Base: getindex, setindex!, checkbounds, @propagate_inbounds, convert,
 import Base.Broadcast: BroadcastStyle, AbstractArrayStyle, DefaultArrayStyle, Broadcasted, broadcasted,
                         materialize, materialize!
 
-import LinearAlgebra: UniformScaling, isdiag, rmul!, lmul!, ldiv!, rdiv!,
+import LinearAlgebra: UniformScaling, isdiag, rmul!, lmul!, ldiv!, rdiv!, axpy!,
                         AbstractTriangular, AdjOrTrans, HermOrSym, StructuredMatrixStyle,
                         qr, qr!
 import LinearAlgebra.BLAS: BlasInt, BlasFloat, @blasfunc, BlasComplex, BlasReal

--- a/test/test_bandedblockbanded.jl
+++ b/test/test_bandedblockbanded.jl
@@ -320,24 +320,24 @@ import ArrayLayouts: RangeCumsum
         V = view(A, Block(N,N))
 
         AN = A[Block(N,N)]
-        BLAS.axpy!(2.0, V, V)
+        axpy!(2.0, V, V)
         @test A[Block(N,N)] ≈ 3AN
 
 
         Y = zeros(cols[N], cols[N])
-        BLAS.axpy!(2.0, V, Y)
+        axpy!(2.0, V, Y)
         @test Y ≈ 2A[Block(N,N)]
 
         Y = BandedMatrix(Zeros(cols[N], cols[N]), (λ, μ))
-        BLAS.axpy!(2.0, V, Y)
+        axpy!(2.0, V, Y)
         @test Y ≈ 2A[Block(N,N)]
 
         Y = BandedMatrix(Zeros(cols[N], cols[N]), (λ+1, μ+1))
-        BLAS.axpy!(2.0, V, Y)
+        axpy!(2.0, V, Y)
         @test Y ≈ 2A[Block(N,N)]
 
         Y = BandedMatrix(Zeros(cols[N], cols[N]), (0, 0))
-        @test_throws BandError BLAS.axpy!(2.0, V, Y)
+        @test_throws BandError axpy!(2.0, V, Y)
     end
 
     @testset "Float32"  begin

--- a/test/test_blockbanded.jl
+++ b/test/test_blockbanded.jl
@@ -173,14 +173,14 @@ import Base.Broadcast: materialize!
         @test MemoryLayout(typeof(V)) == ColumnMajor()
 
         Y = zeros(cols[N], cols[N])
-        @time BLAS.axpy!(2.0, V, Y)
+        @time axpy!(2.0, V, Y)
         @test Y ≈ 2A[Block(N,N)]
 
         Y = BandedMatrix(Zeros(cols[N], cols[N]), (0, 0))
-        @test_throws BandError BLAS.axpy!(2.0, V, Y)
+        @test_throws BandError axpy!(2.0, V, Y)
 
         AN = A[Block(N,N)]
-        @time BLAS.axpy!(2.0, V, V)
+        @time axpy!(2.0, V, V)
         @test A[Block(N,N)] ≈ 3AN
 
         A = BlockBandedMatrix(Ones{Float64}((4,6)), [2,2], [2,2,2], (0,2))

--- a/test/test_blockskylineqr.jl
+++ b/test/test_blockskylineqr.jl
@@ -15,7 +15,7 @@ import BlockBandedMatrices: blockcolsupport
         Q,R = F
         Q̃,R̃ = qr(Matrix(A))
         @test R ≈ R̃
-        @test Q ≈ Q̃
+        @test Matrix(Q) ≈ Matrix(Q̃)
 
         b = randn(size(A,1))
         @test Q'b ≈ Q̃'b
@@ -37,7 +37,7 @@ import BlockBandedMatrices: blockcolsupport
         Q,R = F
         Q̃,R̃ = qr(Matrix(A))
         @test R ≈ R̃
-        @test Q ≈ Q̃
+        @test Matrix(Q) ≈ Matrix(Q̃)
 
         b = randn(size(A,1))
         @test Q'b ≈ Q̃'b
@@ -60,7 +60,7 @@ import BlockBandedMatrices: blockcolsupport
         Q,R = F
         Q̃,R̃ = qr(Matrix(A))
         @test R ≈ R̃
-        @test Q ≈ Q̃
+        @test Matrix(Q) ≈ Matrix(Q̃)
 
         b = randn(size(A,1))
         @test Q'b ≈ Q̃'b
@@ -83,7 +83,7 @@ import BlockBandedMatrices: blockcolsupport
         Q,L = F
         Q̃,L̃ = ql(Matrix(A))
         @test L ≈ L̃
-        @test Q ≈ Q̃
+        @test Matrix(Q) ≈ Matrix(Q̃)
 
         b = randn(size(A,1))
         @test Q'b ≈ Q̃'b
@@ -182,7 +182,7 @@ import BlockBandedMatrices: blockcolsupport
         N = 5
         A = BlockBandedMatrix{BigFloat}(undef, 1:N,1:N, (2,1))
         A.data .= randn.()
-        @test qr(A).Q ≈ qr(Float64.(A)).Q
+        @test Matrix(qr(A).Q) ≈ Matrix(qr(Float64.(A)).Q)
         b = randn(size(A,1))
         @test qr(A .+ 0im)\b ≈ qr(A)\b ≈ A\b
     end

--- a/test/test_linalg.jl
+++ b/test/test_linalg.jl
@@ -135,7 +135,7 @@ end
         @time AB = A + B
         @test AB ≈ Matrix(A) + Matrix(B)
 
-        @time BLAS.axpy!(1.0, A, B)
+        @time axpy!(1.0, A, B)
         @test B ≈ AB
     end
 


### PR DESCRIPTION
Starting from Julia v1.9, `axpy!` is owned by `LinearAlgebra`, and `BLAS.axpy!` does no longer work for non-strided arrays. Also, in the future `AbstractQ` will no longer subtype `AbstractMatrix`, so in tests we need to convert to `Matrix` manually.