### PR TITLE
Don't check for Project.toml formatting on v1.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,10 @@ using Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(BlockBandedMatrices, ambiguities=false, piracy=false)
+    Aqua.test_all(BlockBandedMatrices, ambiguities=false, piracy=false,
+        # only test formatting on VERSION >= v1.7
+        # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        project_toml_formatting = VERSION >= v"1.9")
 end
 
 include("test_blockbanded.jl")


### PR DESCRIPTION
This works around a Pkg bug on v1.6 that doesn't play well with extensions