### PR TITLE
Remove Statistics as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockBandedMatrices"
 uuid = "ffab5731-97b5-5995-9138-79e8c1846df0"
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -10,7 +10,6 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MatrixFactorizations = "a3b82374-2e81-5b9e-98ce-41277c0e4c87"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Aqua = "0.6"


### PR DESCRIPTION
This is a stale dependency that was oddly not flagged by Aqua in this package, but was in `FillArrays.jl`. This led to the test failure in https://github.com/JuliaArrays/FillArrays.jl/pull/286 ([run](https://github.com/JuliaArrays/FillArrays.jl/actions/runs/5673518008/job/15375154861?pr=286))