### PR TITLE
Update result type in triangular-vector multiplication

### DIFF
--- a/test/test_triblockbanded.jl
+++ b/test/test_triblockbanded.jl
@@ -20,31 +20,35 @@ import BlockArrays: BlockedUnitRange, blockisequal
         U = UpperTriangular(A)
         @test MemoryLayout(typeof(U)) == TriangularLayout{'U','N',BandedBlockBandedColumnMajor}()
         b = randn(size(U,1))
-        @test U*b isa Vector{Float64}
-        @test lmul(U,b) == U*b
-        @test U*b  ≈ Matrix(U)*b
+        Ub = U*b
+        @test Ub isa AbstractVector{Float64}
+        @test lmul(U,b) == Ub
+        @test Ub  ≈ Matrix(U)*b
 
         U = UnitUpperTriangular(A)
         @test MemoryLayout(typeof(U)) == TriangularLayout{'U','U',BandedBlockBandedColumnMajor}()
         b = randn(size(U,1))
-        @test U*b isa Vector{Float64}
-        @test lmul(U,b) == U*b
-        @test U*b  ≈ Matrix(U)*b
+        Ub = U*b
+        @test Ub isa AbstractVector{Float64}
+        @test lmul(U,b) == Ub
+        @test Ub  ≈ Matrix(U)*b
 
         L = LowerTriangular(A)
         @test MemoryLayout(typeof(L)) == TriangularLayout{'L','N',BandedBlockBandedColumnMajor}()
         b = randn(size(U,1))
-        @test L*b isa Vector{Float64}
-        @test lmul(L,b) == L*b
-        @test L*b  ≈ Matrix(L)*b
+        Lb = L*b
+        @test Lb isa AbstractVector{Float64}
+        @test lmul(L,b) == Lb
+        @test Lb  ≈ Matrix(L)*b
 
 
         L = UnitLowerTriangular(A)
         @test MemoryLayout(typeof(L)) == TriangularLayout{'L','U',BandedBlockBandedColumnMajor}()
         b = randn(size(L,1))
-        @test L*b isa Vector{Float64}
-        @test lmul(L,b) == L*b
-        @test L*b  ≈ Matrix(L)*b
+        Lb = L*b
+        @test Lb isa AbstractVector{Float64}
+        @test lmul(L,b) == Lb
+        @test Lb  ≈ Matrix(L)*b
     end
 
     @testset "Block by BlockIndex" begin


### PR DESCRIPTION
Since this package owns neither `AbstractTriangular` nor `Vector`, and doesn't specialize their product either, we can't be certain that the type of `AbstractTriangular * Vector` does not change. This is, in fact, the case on v1.11, where
```julia
julia> A = BandedBlockBandedMatrix{Float64}(undef, 1:2,1:2, (1,1), (1,1));

julia> A.data .= randn.();

julia> U = UpperTriangular(A);

julia> b = randn(size(U,2));

julia> U * b
2-blocked 3-element BlockArrays.PseudoBlockVector{Float64, Vector{Float64}, Tuple{BlockArrays.BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}:
 -1.5655580183462696  
 ─────────────────────
  1.9596298000456944  
 -0.037451137182675044
```
This used to return a `Vector` on older versions. The change arises from the fact that an `AbstractTriangular` matrix preserves the axes of the parent.

This PR changes the explicit test for a `Vector` to that for an `AbstractVector`