### PR TITLE
Handle out-of-bounds blockcolstop/blockrowstop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockBandedMatrices"
 uuid = "ffab5731-97b5-5995-9138-79e8c1846df0"
-version = "0.12.10"
+version = "0.12.11"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/AbstractBlockBandedMatrix.jl
+++ b/src/AbstractBlockBandedMatrix.jl
@@ -161,7 +161,7 @@ end
 
 @inline function blockbanded_colstop(A, i::Integer)
     CS = blockcolstop(A,findblock(axes(A,2),i))
-    CS == Block(0) && return 0
+    CS in blockaxes(axes(A,1), 1) || return 0
     last(axes(A,1)[CS])
 end
 
@@ -178,7 +178,7 @@ end
 
 @inline function blockbanded_rowstop(A, i::Integer)
     CS = blockrowstop(A,findblock(axes(A,1),i))
-    CS == Block(0) && return 0
+    CS in blockaxes(axes(A,2), 1) || return 0
     last(axes(A,2)[CS])
 end
 

--- a/test/test_blockskyline.jl
+++ b/test/test_blockskyline.jl
@@ -156,4 +156,10 @@ Random.seed!(0)
             end
         end
     end
+
+    @testset "indexing" begin
+        B = BlockSkylineMatrix{Bool}(I, 1:1, 1:4, ([0,0,0,0],[0,1,1,1]))
+        s = split(sprint(show, "text/plain", B), '\n')[2]
+        @test s == " 1  │  0  0  │  ⋅  ⋅  ⋅  │  ⋅  ⋅  ⋅  ⋅"
+    end
 end


### PR DESCRIPTION
The following works after this:
```julia
julia> using BlockBandedMatrices, LinearAlgebra

julia> B = BlockSkylineMatrix{Bool}(I, 1:1, 1:5, ([0,0,0,0,0],[0,1,1,1,1]))
1×5-blocked 1×15 BlockSkylineMatrix{Bool, Vector{Bool}, BlockBandedMatrices.BlockSkylineSizes{Tuple{BlockArrays.BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}, BlockArrays.BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}, Vector{Int64}, Vector{Int64}, BandedMatrices.BandedMatrix{Int64, Matrix{Int64}, Base.OneTo{Int64}}, Vector{Int64}}}:
 1  │  0  0  │  ⋅  ⋅  ⋅  │  ⋅  ⋅  ⋅  ⋅  │  ⋅  ⋅  ⋅  ⋅  ⋅
```