### PR TITLE
Change more broadcasts over broadcast args to maps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockBandedMatrices"
 uuid = "ffab5731-97b5-5995-9138-79e8c1846df0"
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"


### PR DESCRIPTION
`map` is generally easier on inference than `broadcast`, so we may prefer these.