### PR TITLE
Skip Aqua stale deps check in downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -63,7 +63,7 @@ jobs:
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
-            Pkg.test(; coverage = true)  # resolver may fail with test time deps
+            Pkg.test(; coverage = true, test_args=["--downstream_integration_test"])  # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,8 +2,10 @@ using BlockBandedMatrices
 using Test
 
 import Aqua
+downstream_test = "--downstream_integration_test" in ARGS
 @testset "Project quality" begin
-    Aqua.test_all(BlockBandedMatrices, ambiguities=false, piracies=false)
+    Aqua.test_all(BlockBandedMatrices, ambiguities=false, piracies=false,
+        stale_deps=!downstream_test)
 end
 
 using Documenter


### PR DESCRIPTION
Also, pass the cmd line flag `--downstream_integration_test`  to downstream tests, which may be used to filter tests.